### PR TITLE
stressnet: Higher serialization limits e.g. for very big blocks

### DIFF
--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -45,10 +45,11 @@ void on_levin_traffic(const context_t &context, bool initiator, bool sent, bool 
 
 namespace
 {
+  // Higher limits for stressnet, as a "band aid solution" against bumping against limits e.g. with very big blocks
   static const constexpr epee::serialization::portable_storage::limits_t default_levin_limits = {
-    8192, // objects
-    16384, // fields
-    16384, // strings
+    20000, /* was 8192 */  // objects
+    50000, /* was 16384 */ // fields
+    50000, /* was 16384 */ // strings
   };
 }
 


### PR DESCRIPTION
I found one of the reasons why it's not possible for the daemon to sync in chunks of 20 blocks, as it is default, if the blocks are very large, like 1.5 MB in one particular region of the stressnet blockchain: Some parts of the data it gets from peers when doing so goes over some internal limits that were set a few years ago to make it much harder to crash Monero daemons by feeding them "junk" data that deserializes to hundreds of megabytes.

That's the reason the daemon starts to ban peers: It does not like peers that return data too often that it sees as "corrupt" or even "malicious".

This PR implements a quick "band aid solution" by simply defining higher limits, see the very simple code changes.

My daemon still behaves pretty strangely when I try sync with the default of 20, but well, maybe there are other situations where a daemon or a wallet on stressnet bumps against those limits, thus it might be interesting to try my changes.