### PR TITLE
Raise default outgoing connections limit from 12 to 24

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -132,7 +132,7 @@
 #define P2P_LOCAL_WHITE_PEERLIST_LIMIT                  1000
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   5000
 
-#define P2P_DEFAULT_CONNECTIONS_COUNT                   12
+#define P2P_DEFAULT_CONNECTIONS_COUNT                   24
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //secondes
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
 #define P2P_DEFAULT_PEERS_IN_HANDSHAKE                  250


### PR DESCRIPTION
If all nodes on the network have open ports, on average each node will have total number of connections equal to two times the outgoing connection limit.