### PR TITLE
cryptonote: sync batches instead of single blocks 

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -95,8 +95,8 @@
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
 #define BLOCKS_IDS_SYNCHRONIZING_MAX_COUNT              25000  //max blocks ids count in synchronizing
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       20    //by default, blocks count in blocks downloading
-#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              1     //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
+#define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              5     //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_MAX_COUNT                  2048   //must be a power of 2, greater than 128, equal to SEEDHASH_EPOCH_BLOCKS
 
 #define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -943,7 +943,7 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   size_t core::get_block_sync_size(uint64_t height) const
   {
-    static const uint64_t quick_height = m_nettype == TESTNET ? 2508830 : m_nettype == MAINNET ? 1220516 : 0; // 2508830 is stressnet hardfork height
+    static const uint64_t quick_height = m_nettype == TESTNET ? 2557352 : m_nettype == MAINNET ? 1220516 : 0; // 2557352 is stressnet 251 hardfork height
     size_t res = 0;
     if (block_sync_size > 0)
       res = block_sync_size;


### PR DESCRIPTION
- set the block-sync-size change to reflect the new fork height
- block-sync-size prefork reverted to 100
- block-sync-size postfork increased from 1 to 5. Mainnet is 20, but we'll surpass the 100mb packet size limit if we use 20 (5mb blocks will break catchup syncing)