### PR TITLE
Add ReadWrite locking mechanism on top of Blockchain.

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -100,7 +100,8 @@ Blockchain::Blockchain(tx_memory_pool& tx_pool) :
   m_btc_valid(false),
   m_batch_success(true),
   m_prepare_height(0),
-  m_rct_ver_cache()
+  m_rct_ver_cache(),
+  m_blockchain_transaction()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
 }
@@ -138,9 +139,10 @@ template <class visitor_t>
 bool Blockchain::scan_outputkeys_for_indexes(size_t tx_version, const txin_to_key& tx_in_to_key, visitor_t &vis, const crypto::hash &tx_prefix_hash, uint64_t* pmax_related_block_height) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
+  RLOCK(m_blockchain_transaction);
 
   // ND: Disable locking and make method private.
-  //CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  // m_blockchain_transaction.start_write();
 
   // verify that the input has key offsets (that it exists properly, really)
   if(!tx_in_to_key.key_offsets.size())
@@ -284,8 +286,8 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
 
   CHECK_AND_ASSERT_MES(nettype != FAKECHAIN || test_options, false, "fake chain network type used without options");
 
-  CRITICAL_REGION_LOCAL(m_tx_pool);
-  CRITICAL_REGION_LOCAL1(m_blockchain_lock);
+  RWLOCK(m_tx_pool);
+  RWLOCK(m_blockchain_transaction);
 
   if (db == nullptr)
   {
@@ -552,8 +554,8 @@ bool Blockchain::deinit()
 void Blockchain::pop_blocks(uint64_t nblocks)
 {
   uint64_t i = 0;
-  CRITICAL_REGION_LOCAL(m_tx_pool);
-  CRITICAL_REGION_LOCAL1(m_blockchain_lock);
+  RWLOCK(m_tx_pool);
+  RWLOCK(m_blockchain_transaction);
 
   bool stop_batch = m_db->batch_start();
 
@@ -594,7 +596,7 @@ void Blockchain::pop_blocks(uint64_t nblocks)
 block Blockchain::pop_block_from_blockchain()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
 
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
@@ -681,7 +683,7 @@ block Blockchain::pop_block_from_blockchain()
 bool Blockchain::reset_and_set_genesis_block(const block& b)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
   invalidate_block_template_cache();
@@ -700,7 +702,7 @@ bool Blockchain::reset_and_set_genesis_block(const block& b)
 crypto::hash Blockchain::get_tail_id(uint64_t& height) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RLOCK(m_blockchain_transaction);
   return m_db->top_block_hash(&height);
 }
 //------------------------------------------------------------------
@@ -729,7 +731,7 @@ crypto::hash Blockchain::get_tail_id() const
 bool Blockchain::get_short_chain_history(std::list<crypto::hash>& ids) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   uint64_t i = 0;
   uint64_t current_multiplier = 1;
   uint64_t sz = m_db->height();
@@ -805,8 +807,7 @@ crypto::hash Blockchain::get_pending_block_id_by_height(uint64_t height) const
 bool Blockchain::get_block_by_hash(const crypto::hash &h, block &blk, bool *orphan) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   // try to find block in main chain
   try
   {
@@ -882,7 +883,7 @@ start:
     }
   }
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> difficulties;
   uint64_t height;
@@ -1018,7 +1019,7 @@ size_t Blockchain::recalculate_difficulties(boost::optional<uint64_t> start_heig
     return 0;
   }
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction); 
 
   const uint64_t start_height = start_height_opt ? *start_height_opt : check_difficulty_checkpoints().second;
   const uint64_t top_height = m_db->height() - 1;
@@ -1104,7 +1105,7 @@ size_t Blockchain::recalculate_difficulties(boost::optional<uint64_t> start_heig
 //------------------------------------------------------------------
 std::vector<time_t> Blockchain::get_last_block_timestamps(unsigned int blocks) const
 {
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction); 
   uint64_t height = m_db->height();
   if (blocks > height)
     blocks = height;
@@ -1120,7 +1121,7 @@ std::vector<time_t> Blockchain::get_last_block_timestamps(unsigned int blocks) c
 bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain, uint64_t rollback_height)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction); 
 
   // fail if rollback_height passed is too high
   if (rollback_height > m_db->height())
@@ -1164,8 +1165,7 @@ bool Blockchain::rollback_blockchain_switching(std::list<block>& original_chain,
 bool Blockchain::switch_to_alternative_blockchain(std::list<block_extended_info>& alt_chain, bool discard_disconnected_chain)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
 
@@ -1300,7 +1300,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   // based on its blocks alone, need to get more blocks from the main chain
   if(alt_chain.size()< DIFFICULTY_BLOCKS_COUNT)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RWLOCK(m_blockchain_transaction);
 
     // Figure out start and stop offsets for main chain blocks
     size_t main_chain_stop_offset = alt_chain.size() ? alt_chain.front().height : bei.height;
@@ -1458,7 +1458,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
 void Blockchain::get_last_n_blocks_weights(std::vector<uint64_t>& weights, size_t count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   auto h = m_db->height();
 
   // this function is meaningless for an empty blockchain...granted it should never be empty
@@ -1473,8 +1473,7 @@ void Blockchain::get_last_n_blocks_weights(std::vector<uint64_t>& weights, size_
 uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, size_t count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   PERF_TIMER(get_long_term_block_weights);
 
   CHECK_AND_ASSERT_THROW_MES(count > 0, "count == 0");
@@ -1552,7 +1551,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
   m_tx_pool.lock();
   const auto unlock_guard = epee::misc_utils::create_scope_leave_handler([&]() { m_tx_pool.unlock(); });
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   if (m_btc_valid && !from_block) {
     // The pool cookie is atomic. The lack of locking is OK, as if it changes
     // just as we compare it, we'll just use a slightly old template, but
@@ -1849,7 +1848,7 @@ bool Blockchain::complete_timestamps_vector(uint64_t start_top_height, std::vect
   if(timestamps.size() >= BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW)
     return true;
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   size_t need_elements = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW - timestamps.size();
   CHECK_AND_ASSERT_MES(start_top_height < m_db->height(), false, "internal error: passed start_height not < " << " m_db->height() -- " << start_top_height << " >= " << m_db->height());
   size_t stop_offset = start_top_height > need_elements ? start_top_height - need_elements : 0;
@@ -1927,7 +1926,7 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
   block_verification_context& bvc, pool_supplement& extra_block_txs)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   m_timestamps_and_difficulties_height = 0;
   m_reset_timestamps_and_difficulties_height = true;
   uint64_t block_height = get_block_height(b);
@@ -2193,7 +2192,7 @@ bool Blockchain::handle_alternative_block(const block& b, const crypto::hash& id
 bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks, std::vector<cryptonote::blobdata>& txs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   if(start_offset >= m_db->height())
     return false;
 
@@ -2215,7 +2214,7 @@ bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std
 bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata,block>>& blocks) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   const uint64_t height = m_db->height();
   if(start_offset >= height)
     return false;
@@ -2243,7 +2242,7 @@ bool Blockchain::get_blocks(uint64_t start_offset, size_t count, std::vector<std
 bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NOTIFY_RESPONSE_GET_OBJECTS::request& rsp)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   db_rtxn_guard rtxn_guard (m_db);
   rsp.current_blockchain_height = get_current_blockchain_height();
   std::vector<std::pair<cryptonote::blobdata,block>> blocks;
@@ -2292,8 +2291,7 @@ bool Blockchain::handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS::request& arg, NO
 bool Blockchain::get_alternative_blocks(std::vector<block>& blocks) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   blocks.reserve(m_db->get_alt_block_count());
   m_db->for_all_alt_blocks([&blocks](const crypto::hash &blkid, const cryptonote::alt_block_data_t &data, const cryptonote::blobdata_ref *blob) {
     if (!blob)
@@ -2314,7 +2312,7 @@ bool Blockchain::get_alternative_blocks(std::vector<block>& blocks) const
 size_t Blockchain::get_alternative_blocks_count() const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   return m_db->get_alt_block_count();
 }
 //------------------------------------------------------------------
@@ -2348,8 +2346,7 @@ crypto::public_key Blockchain::get_output_key(uint64_t amount, uint64_t global_i
 bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   res.outs.clear();
   res.outs.reserve(req.outputs.size());
 
@@ -2457,8 +2454,7 @@ bool Blockchain::get_output_distribution(uint64_t amount, uint64_t from_height, 
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, uint64_t& starter_offset) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   // make sure the request includes at least the genesis block, otherwise
   // how can we expect to sync from the client that the block list came from?
   if(qblock_ids.empty())
@@ -2535,8 +2531,7 @@ template<class t_ids_container, class t_blocks_container, class t_missed_contain
 bool Blockchain::get_blocks(const t_ids_container& block_ids, t_blocks_container& blocks, t_missed_container& missed_bs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   reserve_container(blocks, block_ids.size());
   for (const auto& block_hash : block_ids)
   {
@@ -2620,7 +2615,7 @@ static bool fill(BlockchainDB *db, const crypto::hash &tx_hash, tx_blob_entry &t
 bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids, std::vector<cryptonote::blobdata>& txs, std::vector<crypto::hash>& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
 
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2644,7 +2639,7 @@ bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids
 bool Blockchain::get_transactions_blobs(const std::vector<crypto::hash>& txs_ids, std::vector<tx_blob_entry>& txs, std::vector<crypto::hash>& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
 
   txs.reserve(txs_ids.size());
   for (const auto& tx_hash : txs_ids)
@@ -2680,8 +2675,7 @@ template<class t_ids_container, class t_tx_container, class t_missed_container>
 bool Blockchain::get_split_transactions_blobs(const t_ids_container& txs_ids, t_tx_container& txs, t_missed_container& missed_txs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
   {
@@ -2714,8 +2708,7 @@ template<class t_ids_container, class t_tx_container, class t_missed_container>
 bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container& txs, t_missed_container& missed_txs, bool pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   reserve_container(txs, txs_ids.size());
   for (const auto& tx_hash : txs_ids)
   {
@@ -2750,8 +2743,7 @@ bool Blockchain::get_transactions(const t_ids_container& txs_ids, t_tx_container
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, std::vector<crypto::hash>& hashes, std::vector<uint64_t>* weights, uint64_t& start_height, uint64_t& current_height, bool clip_pruned) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   // if we can't find the split point, return false
   if(!find_blockchain_supplement(qblock_ids, start_height))
   {
@@ -2789,8 +2781,7 @@ bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qbloc
 bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   bool result = find_blockchain_supplement(qblock_ids, resp.m_block_ids, &resp.m_block_weights, resp.start_height, resp.total_height, clip_pruned);
   if (result)
   {
@@ -2809,8 +2800,7 @@ bool Blockchain::find_blockchain_supplement(const std::list<crypto::hash>& qbloc
 bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   // if a specific start height has been requested
   if(req_start_block > 0)
   {
@@ -2852,7 +2842,7 @@ bool Blockchain::add_block_as_invalid(const block& bl, const crypto::hash& h)
 bool Blockchain::add_block_as_invalid(const block_extended_info& bei, const crypto::hash& h)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   auto i_res = m_invalid_blocks.insert(std::map<crypto::hash, block_extended_info>::value_type(h, bei));
   CHECK_AND_ASSERT_MES(i_res.second, false, "at insertion invalid by tx returned status existed");
   MINFO("BLOCK ADDED AS INVALID: " << h << std::endl << ", prev_id=" << bei.bl.prev_id << ", m_invalid_blocks count=" << m_invalid_blocks.size());
@@ -2862,7 +2852,7 @@ bool Blockchain::add_block_as_invalid(const block_extended_info& bei, const cryp
 void Blockchain::flush_invalid_blocks()
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   m_invalid_blocks.clear();
 }
 //------------------------------------------------------------------
@@ -2900,7 +2890,6 @@ bool Blockchain::have_block_unlocked(const crypto::hash& id, int *where) const
 //------------------------------------------------------------------
 bool Blockchain::have_block(const crypto::hash& id, int *where) const
 {
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
   return have_block_unlocked(id, where);
 }
 //------------------------------------------------------------------
@@ -2931,7 +2920,7 @@ size_t Blockchain::get_total_transactions() const
 bool Blockchain::check_for_double_spend(const transaction& tx, key_images_container& keys_this_block) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   struct add_transaction_input_visitor: public boost::static_visitor<bool>
   {
     key_images_container& m_spent_keys;
@@ -2991,7 +2980,7 @@ bool Blockchain::check_for_double_spend(const transaction& tx, key_images_contai
 bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes, std::vector<std::vector<uint64_t>>& indexs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   uint64_t tx_index;
   if (!m_db->tx_exists(tx_id, tx_index))
   {
@@ -3007,7 +2996,7 @@ bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes
 bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, std::vector<uint64_t>& indexs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   uint64_t tx_index;
   if (!m_db->tx_exists(tx_id, tx_index))
   {
@@ -3031,8 +3020,7 @@ bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, std::vector<u
 bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_height, crypto::hash& max_used_block_id, tx_verification_context &tvc, bool kept_by_block) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
 #if defined(PER_BLOCK_CHECKPOINT)
   // check if we're doing per-block checkpointing
   if (m_db->height() < m_blocks_hash_check.size() && kept_by_block)
@@ -3883,7 +3871,7 @@ bool Blockchain::check_tx_input(size_t tx_version, const txin_to_key& txin, cons
 
   // ND:
   // 1. Disable locking and make method private.
-  //CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  // RWLOCK(m_blockchain_transaction)
 
   struct outputs_visitor
   {
@@ -4025,7 +4013,7 @@ bool Blockchain::check_block_timestamp(const block& b, uint64_t& median_ts) cons
 //------------------------------------------------------------------
 bool Blockchain::flush_txes_from_pool(const std::vector<crypto::hash> &txids)
 {
-  CRITICAL_REGION_LOCAL(m_tx_pool);
+  RWLOCK(m_tx_pool);
 
   bool res = true;
   for (const auto &txid: txids)
@@ -4054,7 +4042,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   LOG_PRINT_L3("Blockchain::" << __func__);
 
   TIME_MEASURE_START(block_processing_time);
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   TIME_MEASURE_START(t1);
 
   static bool seen_future_version = false;
@@ -4532,8 +4520,7 @@ bool Blockchain::prune_blockchain(uint32_t pruning_seed)
 {
   m_tx_pool.lock();
   epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   return m_db->prune_blockchain(pruning_seed);
 }
 //------------------------------------------------------------------
@@ -4541,8 +4528,7 @@ bool Blockchain::update_blockchain_pruning()
 {
   m_tx_pool.lock();
   epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   return m_db->update_pruning();
 }
 //------------------------------------------------------------------
@@ -4550,8 +4536,7 @@ bool Blockchain::check_blockchain_pruning()
 {
   m_tx_pool.lock();
   epee::misc_utils::auto_scope_leave_caller unlocker = epee::misc_utils::create_scope_leave_handler([&](){m_tx_pool.unlock();});
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   return m_db->check_pruning();
 }
 //------------------------------------------------------------------
@@ -4660,8 +4645,10 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
 
   LOG_PRINT_L3("Blockchain::" << __func__);
   crypto::hash id = get_block_hash(bl);
-  CRITICAL_REGION_LOCAL(m_tx_pool);//to avoid deadlock lets lock tx_pool for whole add/reorganize process
-  CRITICAL_REGION_LOCAL1(m_blockchain_lock);
+
+  // To avoid deadlock lets lock tx_pool for whole add/reorganize process
+  RWLOCK(m_tx_pool);
+  RWLOCK(m_blockchain_transaction);
   db_rtxn_guard rtxn_guard(m_db);
   if(have_block(id))
   {
@@ -4682,7 +4669,6 @@ bool Blockchain::add_new_block(const block& bl, block_verification_context& bvc,
 
   rtxn_guard.stop();
   return handle_block_to_main_chain(bl, id, bvc, extra_block_txs);
-
   }
   catch (const std::exception &e)
   {
@@ -4699,7 +4685,7 @@ void Blockchain::check_against_checkpoints(const checkpoints& points, bool enfor
   const auto& pts = points.get_points();
   bool stop_batch;
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
+  RWLOCK(m_blockchain_transaction);
   stop_batch = m_db->batch_start();
   const uint64_t blockchain_height = m_db->height();
   for (const auto& pt : pts)
@@ -4797,7 +4783,8 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
   bool success = false;
 
   MTRACE("Blockchain::" << __func__);
-  CRITICAL_REGION_BEGIN(m_blockchain_lock);
+  bool release_required = m_blockchain_transaction.start_write();
+
   TIME_MEASURE_START(t1);
 
   try
@@ -4860,7 +4847,7 @@ bool Blockchain::cleanup_handle_incoming_blocks(bool force_sync)
     m_blocks_hash_check.shrink_to_fit();
   }
 
-  CRITICAL_REGION_END();
+  if (release_required) m_blockchain_transaction.end_write();
   m_tx_pool.unlock();
 
   update_blockchain_pruning();
@@ -4892,8 +4879,7 @@ uint64_t Blockchain::prevalidate_block_hashes(uint64_t height, const std::vector
 
   CHECK_AND_ASSERT_MES(weights.empty() || weights.size() == hashes.size(), 0, "Unexpected weights size");
 
-  CRITICAL_REGION_LOCAL(m_blockchain_lock);
-
+  RWLOCK(m_blockchain_transaction);
   // easy case: height >= hashes
   if (height >= m_blocks_hash_of_hashes.size() * HASH_OF_HASHES_STEP)
     return hashes.size();
@@ -5048,7 +5034,12 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   //  txpool and blockchain locks were not held
 
   m_tx_pool.lock();
-  CRITICAL_REGION_LOCAL1(m_blockchain_lock);
+  // This locking is special case, lets handle it manually
+  bool release_required = m_blockchain_transaction.start_write();
+  epee::misc_utils::auto_scope_leave_caller scope_exit_handler = 
+    epee::misc_utils::create_scope_leave_handler([&](){
+      if (release_required) m_blockchain_transaction.end_write();
+    });
 
   if(blocks_entry.size() == 0)
     return false;
@@ -5064,11 +5055,11 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
   }
   m_bytes_to_sync += bytes;
   while (!(stop_batch = m_db->batch_start(blocks_entry.size(), bytes))) {
-    m_blockchain_lock.unlock();
+    m_blockchain_transaction.end_write();
     m_tx_pool.unlock();
     epee::misc_utils::sleep_no_w(1000);
     m_tx_pool.lock();
-    m_blockchain_lock.lock();
+    m_blockchain_transaction.start_write();
   }
   m_batch_success = true;
 
@@ -5155,8 +5146,13 @@ bool Blockchain::prepare_handle_incoming_blocks(const std::vector<block_complete
         thread_height += nblocks;
       }
 
+      release_required = false;
+      m_blockchain_transaction.end_write();
+      m_tx_pool.unlock();
       if (!waiter.wait())
         return false;
+      m_tx_pool.lock();
+      release_required = m_blockchain_transaction.start_write();
       m_prepare_height = 0;
 
       if (m_cancel)
@@ -5441,7 +5437,7 @@ void Blockchain::add_block_notify(BlockNotifyCallback&& notify)
 {
   if (notify)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RWLOCK(m_blockchain_transaction);
     m_block_notifiers.push_back(std::move(notify));
   }
 }
@@ -5450,7 +5446,7 @@ void Blockchain::add_miner_notify(MinerNotifyCallback&& notify)
 {
   if (notify)
   {
-    CRITICAL_REGION_LOCAL(m_blockchain_lock);
+    RWLOCK(m_blockchain_transaction);
     m_miner_notifiers.push_back(std::move(notify));
   }
 }
@@ -5637,7 +5633,7 @@ void Blockchain::load_compiled_in_block_hashes(const GetCheckpointsCallback& get
         // The core will not call check_tx_inputs(..) for these
         // transactions in this case. Consequently, the sanity check
         // for tx hashes will fail in handle_block_to_main_chain(..)
-        CRITICAL_REGION_LOCAL(m_tx_pool);
+        RWLOCK(m_tx_pool);
 
         std::vector<transaction> txs;
         m_tx_pool.get_transactions(txs, true);
@@ -5669,12 +5665,12 @@ bool Blockchain::is_within_compiled_block_hash_area(uint64_t height) const
 
 void Blockchain::lock()
 {
-  m_blockchain_lock.lock();
+  m_blockchain_transaction.start_write();
 }
 
 void Blockchain::unlock()
 {
-  m_blockchain_lock.unlock();
+  m_blockchain_transaction.end_write();
 }
 
 bool Blockchain::for_all_key_images(std::function<bool(const crypto::key_image&)> f) const

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -114,6 +114,23 @@ namespace cryptonote
     };
 
     /**
+     * @brief serialize the access to blockchain data
+    */
+   
+    bool start_write() {
+      return m_blockchain_transaction.start_write();
+    }
+    void end_write() {
+      m_blockchain_transaction.end_write();      
+    }
+    void start_read() {
+      m_blockchain_transaction.start_read();
+    }
+    void end_read() {
+      m_blockchain_transaction.end_read();
+    }
+
+    /**
      * @brief Blockchain destructor
      */
     ~Blockchain();
@@ -1149,7 +1166,7 @@ namespace cryptonote
 
     tx_memory_pool& m_tx_pool;
 
-    mutable epee::critical_section m_blockchain_lock; // TODO: add here reader/writer lock
+    mutable epee::reader_writer_lock m_blockchain_transaction;
 
     // main chain
     size_t m_current_block_cumul_weight_limit;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -121,7 +121,7 @@ namespace cryptonote
   }
   //---------------------------------------------------------------------------------
   //---------------------------------------------------------------------------------
-  tx_memory_pool::tx_memory_pool(Blockchain& bchs): m_blockchain(bchs), m_cookie(0), m_txpool_max_weight(DEFAULT_TXPOOL_MAX_WEIGHT), m_txpool_weight(0), m_mine_stem_txes(false), m_next_check(std::time(nullptr))
+  tx_memory_pool::tx_memory_pool(Blockchain& bchs): m_blockchain(bchs), m_cookie(0), m_txpool_max_weight(DEFAULT_TXPOOL_MAX_WEIGHT), m_txpool_weight(0), m_mine_stem_txes(false), m_next_check(std::time(nullptr)), m_transactions_lock()
   {
     // class code expects unsigned values throughout
     if (m_next_check < time_t(0))
@@ -142,7 +142,8 @@ namespace cryptonote
     const bool kept_by_block = (tx_relay == relay_method::block);
 
     // this should already be called with that lock, but let's make it explicit for clarity
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    
+    RWLOCK(m_transactions_lock);
 
     PERF_TIMER(add_tx);
 
@@ -249,7 +250,7 @@ namespace cryptonote
         {
           if (kept_by_block)
             m_parsed_tx_cache.insert(std::make_pair(id, tx));
-          CRITICAL_REGION_LOCAL1(m_blockchain);
+          RWLOCK(m_blockchain);
           LockedTXN lock(m_blockchain.get_db());
           if (!insert_key_images(tx, id, tx_relay))
             return false;
@@ -278,7 +279,7 @@ namespace cryptonote
       {
         if (kept_by_block)
           m_parsed_tx_cache.insert(std::make_pair(id, tx));
-        CRITICAL_REGION_LOCAL1(m_blockchain);
+        RWLOCK(m_blockchain);
         LockedTXN lock(m_blockchain.get_db());
 
         const bool existing_tx = m_blockchain.get_txpool_tx_meta(id, meta);
@@ -368,13 +369,13 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_txpool_weight() const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    RLOCK(m_transactions_lock);
     return m_txpool_weight;
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::set_txpool_max_weight(size_t bytes)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    RWLOCK(m_transactions_lock);
     m_txpool_max_weight = bytes;
   }
   //---------------------------------------------------------------------------------
@@ -393,16 +394,16 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::prune(size_t bytes)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-
+    RWLOCK(m_transactions_lock);
     // Nothing to do if already empty
     if (m_txs_by_fee_and_receive_time.empty())
       return;
 
     if (bytes == 0)
       bytes = m_txpool_max_weight;
+    RWLOCK(m_blockchain);
 
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+
     LockedTXN lock(m_blockchain.get_db());
     bool changed = false;
 
@@ -501,8 +502,8 @@ namespace cryptonote
   //       is treated properly.  Should probably not return early, however.
   bool tx_memory_pool::remove_transaction_keyimages(const transaction_prefix& tx, const crypto::hash &actual_hash)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     // ND: Speedup
     for(const txin_v& vi: tx.vin)
     {
@@ -531,8 +532,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::take_tx(const crypto::hash &id, transaction &tx, cryptonote::blobdata &txblob, size_t& tx_weight, uint64_t& fee, bool &relayed, bool &do_not_relay, bool &double_spend_seen, bool &pruned)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     bool sensitive = false;
     try
@@ -587,8 +588,8 @@ namespace cryptonote
   bool tx_memory_pool::get_transaction_info(const crypto::hash &txid, tx_details &td, bool include_sensitive_data, bool include_blob) const
   {
     PERF_TIMER(get_transaction_info);
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     try
     {
@@ -646,8 +647,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   bool tx_memory_pool::get_transactions_info(const std::vector<crypto::hash>& txids, std::vector<std::pair<crypto::hash, tx_details>>& txs, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     txs.clear();
 
@@ -665,8 +666,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::get_complement(const std::vector<crypto::hash> &hashes, std::vector<cryptonote::blobdata> &txes) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     m_blockchain.for_all_txpool_txes([this, &hashes, &txes](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       const auto tx_relay_method = meta.get_relay_method();
@@ -709,8 +710,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::remove_stuck_transactions()
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     std::list<std::pair<crypto::hash, uint64_t>> remove;
     m_blockchain.for_all_txpool_txes([this, &remove](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref*) {
       uint64_t tx_age = time(nullptr) - meta.receive_time;
@@ -773,8 +774,8 @@ namespace cryptonote
     uint64_t next_check = clock::to_time_t(clock::from_time_t(time_t(now)) + max_relayable_check);
     std::vector<std::pair<crypto::hash, txpool_tx_meta_t>> change_timestamps;
 
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     LockedTXN lock(m_blockchain.get_db());
     txs.reserve(m_blockchain.get_txpool_tx_count());
     m_blockchain.for_all_txpool_txes([this, now, &txs, &change_timestamps, &next_check](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *){
@@ -848,8 +849,8 @@ namespace cryptonote
     const auto now = std::chrono::system_clock::now();
     uint64_t next_relay = uint64_t{std::numeric_limits<time_t>::max()};
 
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     LockedTXN lock(m_blockchain.get_db());
     for (const auto& hash : hashes)
     {
@@ -894,15 +895,15 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_transactions_count(bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     return m_blockchain.get_txpool_tx_count(include_sensitive);
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::get_transactions(std::vector<transaction>& txs, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
     txs.reserve(m_blockchain.get_txpool_tx_count(include_sensitive));
     m_blockchain.for_all_txpool_txes([&txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd){
@@ -921,8 +922,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_hashes(std::vector<crypto::hash>& txs, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
     txs.reserve(m_blockchain.get_txpool_tx_count(include_sensitive));
     m_blockchain.for_all_txpool_txes([&txs](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd){
@@ -933,8 +934,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   bool tx_memory_pool::get_pool_info(time_t start_time, bool include_sensitive, size_t max_tx_count, std::vector<std::pair<crypto::hash, tx_details>>& added_txs, std::vector<crypto::hash>& remaining_added_txids, std::vector<crypto::hash>& removed_txs, bool& incremental) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     incremental = true;
     if (start_time == (time_t)0)
@@ -1008,8 +1009,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_backlog(std::vector<tx_backlog_entry>& backlog, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     const uint64_t now = time(NULL);
     const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
     backlog.reserve(m_blockchain.get_txpool_tx_count(include_sensitive));
@@ -1021,8 +1022,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_block_template_backlog(std::vector<tx_block_template_backlog_entry>& backlog, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     std::vector<tx_block_template_backlog_entry> tmp;
     uint64_t total_weight = 0;
@@ -1082,8 +1083,8 @@ namespace cryptonote
   //------------------------------------------------------------------
   void tx_memory_pool::get_transaction_stats(struct txpool_stats& stats, bool include_sensitive) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     const uint64_t now = time(NULL);
     const relay_category category = include_sensitive ? relay_category::all : relay_category::broadcasted;
     std::map<uint64_t, txpool_histo> agebytes;
@@ -1169,8 +1170,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::get_transactions_and_spent_keys_info(std::vector<tx_info>& tx_infos, std::vector<spent_key_image_info>& key_image_infos, bool include_sensitive_data) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     const relay_category category = include_sensitive_data ? relay_category::all : relay_category::broadcasted;
     const size_t count = m_blockchain.get_txpool_tx_count(include_sensitive_data);
     tx_infos.reserve(count);
@@ -1227,8 +1228,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::get_pool_for_rpc(std::vector<cryptonote::rpc::tx_in_pool>& tx_infos, cryptonote::rpc::key_images_with_tx_hashes& key_image_infos) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     tx_infos.reserve(m_blockchain.get_txpool_tx_count());
     key_image_infos.reserve(m_blockchain.get_txpool_tx_count());
     m_blockchain.for_all_txpool_txes([&tx_infos, key_image_infos](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *bd){
@@ -1275,8 +1276,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::check_for_key_images(const std::vector<crypto::key_image>& key_images, std::vector<bool>& spent) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     spent.clear();
 
@@ -1297,8 +1298,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::get_transaction(const crypto::hash& id, cryptonote::blobdata& txblob, relay_category tx_category) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     try
     {
       return m_blockchain.get_txpool_tx_blob(id, txblob, tx_category);
@@ -1311,7 +1312,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::on_blockchain_inc(uint64_t new_block_height, const crypto::hash& top_block_id)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    RWLOCK(m_transactions_lock);
     m_input_cache.clear();
     m_parsed_tx_cache.clear();
     return true;
@@ -1319,7 +1320,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::on_blockchain_dec(uint64_t new_block_height, const crypto::hash& top_block_id)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    RWLOCK(m_transactions_lock);
     m_input_cache.clear();
     m_parsed_tx_cache.clear();
     return true;
@@ -1327,15 +1328,15 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_tx(const crypto::hash &id, relay_category tx_category) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     return m_blockchain.get_db().txpool_has_tx(id, tx_category);
   }
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_tx_keyimges_as_spent(const transaction& tx, const crypto::hash& txid) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, const txin_to_key, tokey_in, true);//should never fail
@@ -1347,7 +1348,7 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::have_tx_keyimg_as_spent(const crypto::key_image& key_im, const crypto::hash& txid) const
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
+    RLOCK(m_transactions_lock);
     const auto found = m_spent_key_images.find(key_im);
     if (found != m_spent_key_images.end() && !found->second.empty())
     {
@@ -1362,12 +1363,12 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::lock() const
   {
-    m_transactions_lock.lock();
+    m_transactions_lock.start_write();
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::unlock() const
   {
-    m_transactions_lock.unlock();
+    m_transactions_lock.end_write();
   }
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::check_tx_inputs(const std::function<cryptonote::transaction&(void)> &get_tx, const crypto::hash &txid, uint64_t &max_used_block_height, crypto::hash &max_used_block_id, tx_verification_context &tvc, bool kept_by_block) const
@@ -1462,8 +1463,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   void tx_memory_pool::mark_double_spend(const transaction &tx)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     bool changed = false;
     LockedTXN lock(m_blockchain.get_db());
     for(size_t i = 0; i!= tx.vin.size(); i++)
@@ -1507,8 +1508,8 @@ namespace cryptonote
   std::string tx_memory_pool::print_pool(bool short_format) const
   {
     std::stringstream ss;
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
     m_blockchain.for_all_txpool_txes([&ss, short_format](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *txblob) {
       ss << "id: " << txid << std::endl;
       if (!short_format) {
@@ -1539,8 +1540,8 @@ namespace cryptonote
   //TODO: investigate whether boolean return is appropriate
   bool tx_memory_pool::fill_block_template(block &bl, size_t median_weight, uint64_t already_generated_coins, size_t &total_weight, uint64_t &fee, uint64_t &expected_reward, uint8_t version)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     uint64_t best_coinbase = 0, coinbase = 0;
     total_weight = 0;
@@ -1684,8 +1685,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::validate(uint8_t version)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     // Simply throw away incremental info, too difficult to update
     m_added_txs_by_id.clear();
@@ -1856,8 +1857,8 @@ namespace cryptonote
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::init(size_t max_txpool_weight, bool mine_stem_txes)
   {
-    CRITICAL_REGION_LOCAL(m_transactions_lock);
-    CRITICAL_REGION_LOCAL1(m_blockchain);
+    RWLOCK(m_transactions_lock);
+    RWLOCK(m_blockchain);
 
     m_txpool_max_weight = max_txpool_weight ? max_txpool_weight : DEFAULT_TXPOOL_MAX_WEIGHT;
     m_txs_by_fee_and_receive_time.clear();

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -627,10 +627,25 @@ namespace cryptonote
      */
     typedef std::unordered_map<crypto::key_image, std::unordered_set<crypto::hash>> key_images_container;
 
+public:
+
+    bool start_write() {
+      return m_transactions_lock.start_write();
+    }
+    void end_write() {
+      m_transactions_lock.end_write();      
+    }
+    void start_read() {
+      m_transactions_lock.start_read();
+    }
+    void end_read() {
+      m_transactions_lock.end_read();
+    }
+
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
 public:
 #endif
-    mutable epee::critical_section m_transactions_lock;  //!< lock for the pool
+      mutable epee::reader_writer_lock m_transactions_lock;
 #if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
 private:
 #endif

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -102,7 +102,8 @@ set(unit_tests_sources
   is_hdd.cpp
   aligned.cpp
   rpc_version_str.cpp
-  zmq_rpc.cpp)
+  zmq_rpc.cpp
+  reader_writer_lock_tests.cpp)
 
 set(unit_tests_headers
   unit_tests_utils.h)

--- a/tests/unit_tests/reader_writer_lock_tests.cpp
+++ b/tests/unit_tests/reader_writer_lock_tests.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2018-2023, The Monero Project
+
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "gtest/gtest.h"
+#include "syncobj.h"
+#include "boost/thread.hpp"
+
+#include <random>
+
+// number of times each test runs
+int test_iteration = 2;
+
+// total number of threads 
+size_t total_number_of_threads;
+// Between 20-80% of the total number of threads.
+size_t number_of_writers;
+// Remaining number of threads.
+size_t number_of_readers;
+
+// Cycles that readers are going to hold the lock. between 2-100 cycles
+constexpr size_t reading_cycles_min = 2;
+constexpr size_t reading_cycles_max = 25;
+// Duration that readers are going to hold the lock. between 5-100 milliseconds
+constexpr size_t reading_step_duration_min = 2;
+constexpr size_t reading_step_duration_max = 10;
+
+// Cycles that writers are going to hold the lock, between 2-100 cycles
+constexpr size_t writing_cycles_min = 2;
+constexpr size_t writing_cycles_max = 25;
+// Duration that writers are going to hold the lock. between 5-100 milliseconds
+constexpr size_t writing_step_duration_min = 2;
+constexpr size_t writing_step_duration_max = 10;
+
+epee::reader_writer_lock main_lock;
+
+void calculate_parameters(size_t threads) {
+  total_number_of_threads = threads;
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> d( total_number_of_threads * 0.2 , total_number_of_threads * 0.8); 
+
+  number_of_writers = d(rng);
+  number_of_readers = total_number_of_threads - number_of_writers;
+}
+
+void reader() {
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> d(reading_cycles_min, reading_cycles_max); 
+  size_t reading_cycles = d(rng);
+
+  d = std::uniform_int_distribution<std::mt19937::result_type>(reading_step_duration_min, reading_step_duration_max);  
+  bool release_required = main_lock.start_read();
+  for(int i = 0; i < reading_cycles; i++) {
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(d(rng)));
+  }
+  bool recurse = !((bool) std::uniform_int_distribution<std::mt19937::result_type>(0, 10)(rng) % 4); // ~30%
+  if (recurse) {
+    reader();
+  }  
+  if (release_required) main_lock.end_read();
+}
+
+void writer() {
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> d(writing_cycles_min, writing_cycles_max); 
+  size_t writing_cycles = d(rng);
+
+  d = std::uniform_int_distribution<std::mt19937::result_type>(writing_step_duration_min, writing_step_duration_max);  
+  bool release_required = main_lock.start_write();
+  for(int i = 0; i < writing_cycles; i++) {
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(d(rng)));
+  }
+  bool recurse = !((bool) std::uniform_int_distribution<std::mt19937::result_type>(0, 10)(rng) % 4); // ~20%
+  if (recurse) {
+    bool which = std::uniform_int_distribution<std::mt19937::result_type>(0, 10)(rng) % 2;
+    if (which) {
+      writer();
+    }
+    else {
+      reader();
+    }
+  }  
+  if (release_required) main_lock.end_write();
+}
+
+void RUN_TEST() {
+  std::vector<boost::thread> threads;
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> d(0, 10); 
+
+  int reader_count = 0;
+  int writer_count = 0;
+  while(reader_count  < number_of_readers 
+        || writer_count  < number_of_writers ) {
+    bool which_one = d(rng) % 2;
+    if(which_one) {
+      threads.push_back(boost::thread(reader)); reader_count++;
+    }
+    else {
+      threads.push_back(boost::thread(writer)); writer_count++;
+    }
+  }
+
+  std::for_each(threads.begin(), threads.end(), [] (boost::thread& thread) {
+    if (thread.joinable()) thread.join();
+  });
+}
+
+TEST(reader_writer_lock_tests, test_3)
+{
+  calculate_parameters(3);
+  for(int i = 0; i < test_iteration; ++i)
+    RUN_TEST();
+}
+
+TEST(reader_writer_lock_tests, test_5)
+{
+  calculate_parameters(5);
+  for(int i = 0; i < test_iteration; ++i) 
+    RUN_TEST();
+}
+
+TEST(reader_writer_lock_tests, test_10)
+{
+  calculate_parameters(10);
+  for(int i = 0; i < test_iteration; ++i)
+    RUN_TEST();
+}
+
+TEST(reader_writer_lock_tests, test_100)
+{
+  calculate_parameters(100);
+  for(int i = 0; i < test_iteration; ++i)
+    RUN_TEST();
+}
+
+TEST(reader_writer_lock_tests, test_500)
+{
+  calculate_parameters(500);
+  for(int i = 0; i < test_iteration; ++i)
+    RUN_TEST();
+}
+
+TEST(reader_writer_lock_tests, test_1000)
+{
+  calculate_parameters(1000);
+  for(int i = 0; i < test_iteration; ++i)
+    RUN_TEST();
+}


### PR DESCRIPTION
This will fix existing locking issues, and provide a foundation to implement more fine-grained locking mechanisms in future works. reader_writer_lock include wait_queue to prevent writer starvation. In this design, order between read(s) and write will be preserved.