### PR TITLE
rpc_version_str.cpp: allow 3 digits

### DIFF
--- a/src/rpc/rpc_version_str.cpp
+++ b/src/rpc/rpc_version_str.cpp
@@ -45,7 +45,7 @@ namespace rpc
 bool is_version_string_valid(const std::string& str)
 {
     return std::regex_match(str, std::regex(
-        "^\\d{1,2}(\\.\\d{1,2}){3}(-(release|[0-9a-f]{9}))?$",
+        "^\\d{1,3}(\\.\\d{1,3}){1,4}(-(release|[0-9a-f]{9}))?$",
         std::regex_constants::nosubs
     ));
 }


### PR DESCRIPTION
to play around with / confirm the regex works, the below can be pasted into an online c++ compiler e.g. https://www.onlinegdb.com/
``` c++
#include <iostream>
#include <regex>
#include <string>
#include <cassert>

bool is_version_string_valid(const std::string& str)
{
    return std::regex_match(str, std::regex(
        "^\\d{1,3}(\\.\\d{1,3}){1,4}(-(release|[0-9a-f]{9}))?$",
        std::regex_constants::nosubs
    ));
}

void test_is_version_string_valid()
{
    assert(is_version_string_valid("250.0.14.1.2"));
    assert(is_version_string_valid("0.14.1.2"));
    assert(is_version_string_valid("0.15.0.0-release"));
    assert(is_version_string_valid("0.15.0.0-fe3f6a3e6"));
    assert(!is_version_string_valid(""));
    assert(!is_version_string_valid("invalid"));
    assert(!is_version_string_valid("0.15.0.0-invalid"));
    assert(!is_version_string_valid("0.15.0.0-release0"));
    assert(!is_version_string_valid("0.15.0.0-release "));
    assert(!is_version_string_valid("0.15.0.0-fe3f6a3e60"));
    assert(!is_version_string_valid("0.15.0.0-fe3f6a3e6 "));
    std::cout << "All tests passed!" << std::endl;
}

int main()
{
    test_is_version_string_valid();
    return 0;
}

```